### PR TITLE
Updated font-weight to 700 (standard bold) for Android bold fix.

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
   },
   text: {
     color: '#000',
-    fontWeight: '800',
+    fontWeight: '700', // bold
     fontSize: 24
   },
   header: {


### PR DESCRIPTION
Problem: Android AVD did not display a bold heading.

Fix: Updated font-weight to 700 (standard bold).